### PR TITLE
Use the originals folder as the source for images to resize

### DIFF
--- a/infra/configure-params-prod.json
+++ b/infra/configure-params-prod.json
@@ -6,10 +6,10 @@
             "value": "di-func-imageresizev4-prod"
         },
         "imagesStorageAccountName": {
-            "value": "dertinfotestimagessa"
+            "value": "dertinfoliveimagessa"
         },
         "imagesStorageAccountResourceGroup": {
-            "value": "dertinfo-test-rg"
+            "value": "dertinfo-live-rg"
         }
     }
 }

--- a/infra/configure-subscriptions.bicep
+++ b/infra/configure-subscriptions.bicep
@@ -30,9 +30,9 @@ var eventOriginalImagesSubscriptionName = 'di-evgs-event-originals'
 var sheetOriginalImagesSubscriptionName = 'di-evgs-sheet-originals'
 
 // Blob Paths for filtering events
-var groupOriginalImagesFilterPath = 'groupimages/blobs/originals-a/'
-var eventOriginalImagesFilterPath = 'eventimages/blobs/originals-a/'
-var sheetOriginalImagesFilterPath = 'sheetimages/blobs/originals-a/'
+var groupOriginalImagesFilterPath = 'groupimages/blobs/originals/'
+var eventOriginalImagesFilterPath = 'eventimages/blobs/originals/'
+var sheetOriginalImagesFilterPath = 'sheetimages/blobs/originals/'
 
 // #####################################################
 // References

--- a/infra/configure.bicep
+++ b/infra/configure.bicep
@@ -8,7 +8,7 @@ Notes:
 - The application code must be deployed ahead of this configuration
 Azure CLI Commands:
 - az group create --name di-rg-imageresizev4-[env] --location uksouth
-- az deployment group create --resource-group di-rg-imageresizev4-[env] --template-file configure.bicep --parameters @configure-params-stg.json
+- az deployment group create --resource-group di-rg-imageresizev4-[env] --template-file configure.bicep --parameters @configure-params-[env].json
 */
 
 // #####################################################

--- a/src/dertinfo-image-resize/ResizeEventImages.cs
+++ b/src/dertinfo-image-resize/ResizeEventImages.cs
@@ -19,7 +19,7 @@ namespace DertInfo.ImageResize
         }
 
         [Function(nameof(ResizeEventImages))]
-        public async Task Run([BlobTrigger(ImageFolder + "/originals-a/{name}", Source = BlobTriggerSource.EventGrid, Connection = "StorageConnection:Images")] Stream inputBlob, string name)
+        public async Task Run([BlobTrigger(ImageFolder + "/originals/{name}", Source = BlobTriggerSource.EventGrid, Connection = "StorageConnection:Images")] Stream inputBlob, string name)
         {
             _logger.LogInformation($"Resize {ImageFolder} - Processed blob: {name}");
 

--- a/src/dertinfo-image-resize/ResizeGroupImages.cs
+++ b/src/dertinfo-image-resize/ResizeGroupImages.cs
@@ -19,7 +19,7 @@ namespace DertInfo.ImageResize
         }
 
         [Function(nameof(ResizeGroupImages))]
-        public async Task Run([BlobTrigger(ImageFolder + "/originals-a/{name}", Source = BlobTriggerSource.EventGrid, Connection = "StorageConnection:Images")] Stream inputBlob, string name)
+        public async Task Run([BlobTrigger(ImageFolder + "/originals/{name}", Source = BlobTriggerSource.EventGrid, Connection = "StorageConnection:Images")] Stream inputBlob, string name)
         {
             _logger.LogInformation($"Resize {ImageFolder} - Processed blob: {name}");
 

--- a/src/dertinfo-image-resize/ResizeSheetImages.cs
+++ b/src/dertinfo-image-resize/ResizeSheetImages.cs
@@ -19,7 +19,7 @@ namespace DertInfo.ImageResize
         }
 
         [Function(nameof(ResizeSheetImages))]
-        public async Task Run([BlobTrigger(ImageFolder + "/originals-a/{name}", Source = BlobTriggerSource.EventGrid, Connection = "StorageConnection:Images")] Stream inputBlob, string name)
+        public async Task Run([BlobTrigger(ImageFolder + "/originals/{name}", Source = BlobTriggerSource.EventGrid, Connection = "StorageConnection:Images")] Stream inputBlob, string name)
         {
             _logger.LogInformation($"Resize {ImageFolder} - Processed blob: {name}");
 


### PR DESCRIPTION
## Description

Update IaC to correct production configuration & change the image folder back to the originals folder now that we're using event grid. Also update the subject paths on the subscriptions.

As we are now using event grid we don't need the separate folder for the blob trigger as the new function app is not going to try and reprocess all the existing images due to it being a new app and there being no read receipts. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

We're on a tight schedule here to get it open sourced so we'll test when all the pieces come together

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules