### PR TITLE
feat: Add default image resize webhook endpoint

### DIFF
--- a/infra/comms-imagesubs.bicep
+++ b/infra/comms-imagesubs.bicep
@@ -14,6 +14,9 @@ param eventImageResizeWebhookEndpoint string
 @description('Webhook endpoint for sheet images resize function.')
 param sheetImageResizeWebhookEndpoint string 
 
+@description('Webhook endpoint for default images resize function.')
+param defaultImageResizeWebhookEndpoint string 
+
 @description('Webhook endpoint for sheet images resize function.')
 param location string = resourceGroup().location
 
@@ -36,11 +39,13 @@ var systemTopicName = '${producerStorageAccountName}-system-topic'
 var groupOriginalImagesSubscriptionName = 'di-evgs-group-originals'
 var eventOriginalImagesSubscriptionName = 'di-evgs-event-originals'
 var sheetOriginalImagesSubscriptionName = 'di-evgs-sheet-originals'
+var defaultOriginalImagesSubscriptionName = 'di-evgs-sheet-originals'
 
 // Blob Paths for filtering events
 var groupOriginalImagesFilterPath = 'groupimages/blobs/originals/'
 var eventOriginalImagesFilterPath = 'eventimages/blobs/originals/'
 var sheetOriginalImagesFilterPath = 'sheetimages/blobs/originals/'
+var defaultOriginalImagesFilterPath = 'sheetimages/blobs/originals/'
 
 // #####################################################
 // References
@@ -119,6 +124,25 @@ resource sheetSubscriptionSheetImages 'Microsoft.EventGrid/systemTopics/eventSub
         'Microsoft.Storage.BlobCreated'
       ]
       subjectBeginsWith: '/blobServices/default/containers/${sheetOriginalImagesFilterPath}'
+    }
+  }
+}
+
+resource defaultSubscriptionSheetImages 'Microsoft.EventGrid/systemTopics/eventSubscriptions@2023-12-15-preview' = {
+  name: defaultOriginalImagesSubscriptionName
+  parent: systemTopic
+  properties: {
+    destination: {
+      endpointType: 'WebHook'
+      properties: {
+        endpointUrl: defaultImageResizeWebhookEndpoint
+      }
+    }
+    filter: {
+      includedEventTypes: [
+        'Microsoft.Storage.BlobCreated'
+      ]
+      subjectBeginsWith: '/blobServices/default/containers/${defaultOriginalImagesFilterPath}'
     }
   }
 }

--- a/infra/comms.bicep
+++ b/infra/comms.bicep
@@ -44,9 +44,11 @@ var blobExtensionKey = systemKeys.blobs_extension // We want the key with the na
 var groupFunctionName = 'ResizeGroupImages'
 var eventFunctionName = 'ResizeEventImages'
 var sheetFunctionName = 'ResizeSheetImages'
+var defaultFunctionName = 'ResizeDefaultImages'
 var groupImageResizeWebhookEndpoint = 'https://${functionAppName}.azurewebsites.net/runtime/webhooks/blobs?functionName=Host.Functions.${groupFunctionName}&code=${blobExtensionKey}'
 var eventImageResizeWebhookEndpoint = 'https://${functionAppName}.azurewebsites.net/runtime/webhooks/blobs?functionName=Host.Functions.${eventFunctionName}&code=${blobExtensionKey}'
 var sheetImageResizeWebhookEndpoint = 'https://${functionAppName}.azurewebsites.net/runtime/webhooks/blobs?functionName=Host.Functions.${sheetFunctionName}&code=${blobExtensionKey}'
+var defaultImageResizeWebhookEndpoint = 'https://${functionAppName}.azurewebsites.net/runtime/webhooks/blobs?functionName=Host.Functions.${defaultFunctionName}&code=${blobExtensionKey}'
 
 // #####################################################
 // References
@@ -77,6 +79,7 @@ module eventGridSubscriptionsModule './comms-imagesubs.bicep' = {
     groupImageResizeWebhookEndpoint: groupImageResizeWebhookEndpoint
     eventImageResizeWebhookEndpoint: eventImageResizeWebhookEndpoint
     sheetImageResizeWebhookEndpoint: sheetImageResizeWebhookEndpoint
+    defaultImageResizeWebhookEndpoint: defaultImageResizeWebhookEndpoint
     environmentTag: environmentTag
   }
 }

--- a/infra/main-alerting.bicep
+++ b/infra/main-alerting.bicep
@@ -48,7 +48,7 @@ module excessRequestsRuleModule './main-alerting-rule-excessrequests.bicep' = {
     functionAppName: functionAppName
     excessiveUseActionGroupName: excessiveUseActionGroupName
     excessiveUseActionGroupResourceGroup: excessiveUseActionGroupResourceGroup
-    warningThresholdForRequestsPer5mins: (environmentTag == 'prod') ? 100 : 10 
+    warningThresholdForRequestsPer5mins: (environmentTag == 'prod') ? 100 : 30 
     environmentTag: environmentTag
   }
 }

--- a/src/dertinfo-image-resize/ResizeDefaultImages.cs
+++ b/src/dertinfo-image-resize/ResizeDefaultImages.cs
@@ -1,0 +1,36 @@
+﻿using DertInfo.ImageResize.Services;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace DertInfo.ImageResize
+{
+    internal class ResizeDefaultImages
+    {
+        public const string ImageFolder = "defaultimages";
+        private readonly ILogger<ResizeDefaultImages> _logger;
+        private readonly IImageResizeService _imageResizeService;
+        private readonly IBlobWriter _blobWriter;
+
+        public ResizeDefaultImages(ILogger<ResizeDefaultImages> logger, IImageResizeService imageResizeService, IBlobWriter blobWriter)
+        {
+            _logger = logger;
+            _imageResizeService = imageResizeService;
+            _blobWriter = blobWriter;
+        }
+
+        [Function(nameof(ResizeDefaultImages))]
+        public async Task Run([BlobTrigger(ImageFolder + "/originals/{name}", Source = BlobTriggerSource.EventGrid, Connection = "StorageConnection:Images")] Stream inputBlob, string name)
+        {
+            _logger.LogInformation($"Resize {ImageFolder} - Processed blob: {name}");
+
+            // Create the target streams for the resized images.
+            using var stream480x360 = new MemoryStream();
+
+            // Resize the images into the new streams
+            await _imageResizeService.ResizeImageAsync(inputBlob, name, "480x360", stream480x360, true);
+
+            // Write the copy to the 100x100 blobs.
+            await _blobWriter.WriteBlobStream(stream480x360, ImageFolder, $"480x360/{name}");
+        }
+    }
+}


### PR DESCRIPTION
## Description

Added a new webhook endpoint for default image resizing. This allows for resizing of default images when a blob is created in the default image container. The endpoint URL is provided as a parameter and is used to trigger the ResizeDefaultImages function.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I have validated that the other functions work through the event grid events and triggers. This should be no different. Will deploy to staging before prod. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules