### PR TITLE
Add image resizing to 100x100 dimension

### DIFF
--- a/src/dertinfo-image-resize/ResizeDefaultImages.cs
+++ b/src/dertinfo-image-resize/ResizeDefaultImages.cs
@@ -24,9 +24,11 @@ namespace DertInfo.ImageResize
             _logger.LogInformation($"Resize {ImageFolder} - Processed blob: {name}");
 
             // Create the target streams for the resized images.
+            using var stream100x100 = new MemoryStream();
             using var stream480x360 = new MemoryStream();
 
             // Resize the images into the new streams
+            await _imageResizeService.ResizeImageAsync(inputBlob, name, "100x100", stream100x100);
             await _imageResizeService.ResizeImageAsync(inputBlob, name, "480x360", stream480x360, true);
 
             // Write the copy to the 100x100 blobs.


### PR DESCRIPTION


## Description

Introduced a new memory stream (`stream100x100`) and an additional call to `ResizeImageAsync` to resize images to 100x100 dimensions. This ensures images are resized to both 100x100 and 480x360 dimensions.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules