### PR TITLE
Fix: Give the stop function role a unique name

### DIFF
--- a/infra/main-automation.bicep
+++ b/infra/main-automation.bicep
@@ -131,7 +131,7 @@ resource stopWorkloadLogicApp 'Microsoft.Logic/workflows@2019-05-01' = {
 resource customRole 'Microsoft.Authorization/roleDefinitions@2022-05-01-preview' = {
   name: guid(resourceGroup().id, stopWorkloadLogicApp.name, 'FunctionStopRole')
   properties: {
-    roleName: 'CustomRoleStopFunctionApp'
+    roleName: '${stopWorkloadLogicApp.name}-stopfunctionapp-role'
     description: 'Custom role to allow stopping a function app'
     permissions: [
       {


### PR DESCRIPTION
## Description

When deploying to live we had a problem that the role name for the function app in the live environment was not unique. This will have been true as it will have conflicted with the role created for the staging environment. 

I've updated the name of the role so that it takes the name of the logic app to ensure it's uniqueness. Additionally it's going to only ever be used with the managed identity of the logic app with within the resource group so this is relevant.

It is important however that we now cleanup the old role 'CustomRoleStopFunctionApp' from "Microsoft Entra"

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

To address live deployment issues. 

## How Has This Been Tested?

Not possible until deployment as deployment fix

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules